### PR TITLE
Add a maximum for mails to keep

### DIFF
--- a/lib/mail_catcher.rb
+++ b/lib/mail_catcher.rb
@@ -86,6 +86,7 @@ module MailCatcher extend self
     :http_ip => "127.0.0.1",
     :http_port => "1080",
     :http_path => "/",
+    :max_mail_to_keep => -1,
     :verbose => false,
     :daemon => !windows?,
     :browse => false,
@@ -124,6 +125,10 @@ module MailCatcher extend self
 
         parser.on("--http-port PORT", Integer, "Set the port address of the http server") do |port|
           options[:http_port] = port
+        end
+
+        parser.on("--max_mail_to_keep NUM", Integer, "Set the maximum number of mails to keep") do |num|
+          options[:max_mail_to_keep] = num
         end
 
         parser.on("--http-path PATH", String, "Add a prefix to all HTTP paths") do |path|

--- a/lib/mail_catcher/mail.rb
+++ b/lib/mail_catcher/mail.rb
@@ -157,4 +157,13 @@ module MailCatcher::Mail extend self
     @delete_messages_query.execute(message_id) and
     @delete_message_parts_query.execute(message_id)
   end
+
+  def delete_older_messages!(max_mail_to_keep = MailCatcher::options[:max_mail_to_keep])
+    return if max_mail_to_keep == -1
+    @delete_older_messages_query ||= db.prepare "DELETE FROM message WHERE id NOT IN (SELECT id FROM message ORDER BY created_at DESC LIMIT ?)"
+    @delete_older_message_parts_query ||= db.prepare "DELETE FROM message_part WHERE id NOT IN (SELECT id FROM message_part ORDER BY created_at DESC LIMIT ?)"
+
+    @delete_older_messages_query.execute(max_mail_to_keep) and
+    @delete_older_message_parts_query.execute(max_mail_to_keep)
+  end
 end

--- a/lib/mail_catcher/smtp.rb
+++ b/lib/mail_catcher/smtp.rb
@@ -44,6 +44,7 @@ class MailCatcher::Smtp < EventMachine::Protocols::SmtpServer
 
   def receive_message
     MailCatcher::Mail.add_message current_message
+    MailCatcher::Mail.delete_older_messages!
     puts "==> SMTP: Received message from '#{current_message[:sender]}' (#{current_message[:source].length} bytes)"
     true
   rescue => exception


### PR DESCRIPTION
## Context
When `mailcatcher` receives thousand of mails per day the web interface is very slow and can take several minutes to appear.

## Description
This PR adds an option that allows to specify a max number of mail to keep, so `mailcatcher` is responsive when people access it even in case of high catching trafic.

## References
Upstream PR https://github.com/sj26/mailcatcher/pull/375